### PR TITLE
Address defect in nextVersion when old ver is 0

### DIFF
--- a/calver.rb
+++ b/calver.rb
@@ -25,7 +25,7 @@ class Revision
   # if the "next version" we're wanting is for a hotfix, we're going to
   # call Revision#hotfix
   def nextVersion
-    newRevision(@year, @month, @revCount+1)
+    newRevision(@year, @month, @revCount.nil? ? 1 : @revCount + 1)
   end
 
   def hotfix


### PR DESCRIPTION
eg `ruby calver.rb --mode=nextVersion 19.06` should result in `19.06.1`